### PR TITLE
Get last step logic

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ interface Config {
 // The journey manager object
 export interface VoiceCompass {
   updateStep: (data: StepData) => Promise<StepUpdate>;
+  getLastStepId: () => string | null;
   trackDomAnnotations: () => void;
   stopTrackingDomAnnotations: () => void;
 }
@@ -274,6 +275,9 @@ export const create = (config: Config): VoiceCompass => {
 
   return {
     updateStep,
+    getLastStepId: () => {
+      return previousStepId;
+    },
     trackDomAnnotations: () => {
       document.addEventListener("click", handleGlobalClick);
       // The 'blur' even does not bubble, hence 'focusout'


### PR DESCRIPTION
Expose the last step triggered by the SDK. @ndrppnc I'm aware that they wanted `repeatLastStep` but I think it's better to keep the API around this a bit lower-level before we start getting more feature requests like 'can we have repeats configured in a way that step X can not be repeated'.

Implementation for repeat according to this PR:

```ts
client.updateStep({
  stepId: client.getLastStepId()
});
```